### PR TITLE
CMake build

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -26,3 +26,20 @@ jobs:
       format_check_enabled: false
       unacceptable_language_check_enabled: false
       api_breakage_check_enabled: false
+
+  cmake_build:
+    name: CMake Build
+    runs-on: ubuntu-latest
+    container: swift:6.1-noble
+    steps:
+      - name: checkout sources
+        uses: actions/checkout@v1
+      - name: Install dependencies
+        shell: bash
+        run: apt update && apt install -y cmake ninja-build
+      - name: Configure Project
+        shell: bash
+        run: cmake -G 'Ninja' -B build -S . -DCMAKE_C_COMPILER=clang -DCMAKE_Swift_COMPILER=swiftc -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=YES
+      - name: Build Project
+        shell: bash
+        run: cmake --build build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.29)
+project(Subprocess LANGUAGES C Swift)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
+
+add_compile_options("$<$<COMPILE_LANGUAGE:Swift>:SHELL:-package-name ${PROJECT_NAME}>")
+
+include(InstallExternalDependencies)
+
+add_subdirectory(Sources)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.29)
+cmake_minimum_required(VERSION 3.26...3.29)
 project(Subprocess LANGUAGES C Swift)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,14 @@
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift.org open source project
+##
+## Copyright (c) 2025 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0 with Runtime Library Exception
+##
+## See https://swift.org/LICENSE.txt for license information
+##
+##===----------------------------------------------------------------------===##
+
 cmake_minimum_required(VERSION 3.26...3.29)
 project(Subprocess LANGUAGES C Swift)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")

--- a/Package.swift
+++ b/Package.swift
@@ -50,6 +50,7 @@ let package = Package(
                 .product(name: "SystemPackage", package: "swift-system"),
             ],
             path: "Sources/Subprocess",
+            exclude: [ "CMakeLists.txt" ],
             swiftSettings: [
                 .enableExperimentalFeature("StrictConcurrency"),
                 .enableExperimentalFeature("NonescapableTypes"),
@@ -83,7 +84,8 @@ let package = Package(
 
         .target(
             name: "_SubprocessCShims",
-            path: "Sources/_SubprocessCShims"
+            path: "Sources/_SubprocessCShims",
+            exclude: [ "CMakeLists.txt" ]
         ),
     ]
 )

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -1,3 +1,14 @@
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift.org open source project
+##
+## Copyright (c) 2025 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0 with Runtime Library Exception
+##
+## See https://swift.org/LICENSE.txt for license information
+##
+##===----------------------------------------------------------------------===##
+
 add_library(Subprocess)
 
 add_subdirectory(_SubprocessCShims)

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_library(Subprocess)
+
+add_subdirectory(_SubprocessCShims)
+add_subdirectory(Subprocess)
+
+target_compile_options(Subprocess PRIVATE
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature StrictConcurrency>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature NonescapableTyeps>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature LifetimeDependence>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature Span>")
+
+target_link_libraries(Subprocess PRIVATE SystemPackage)

--- a/Sources/Subprocess/CMakeLists.txt
+++ b/Sources/Subprocess/CMakeLists.txt
@@ -1,3 +1,14 @@
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift.org open source project
+##
+## Copyright (c) 2025 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0 with Runtime Library Exception
+##
+## See https://swift.org/LICENSE.txt for license information
+##
+##===----------------------------------------------------------------------===##
+
 target_sources(Subprocess PRIVATE
   Execution.swift
   Buffer.swift

--- a/Sources/Subprocess/CMakeLists.txt
+++ b/Sources/Subprocess/CMakeLists.txt
@@ -1,0 +1,27 @@
+target_sources(Subprocess PRIVATE
+  Execution.swift
+  Buffer.swift
+  Error.swift
+  Teardown.swift
+  Result.swift
+  IO/Output.swift
+  IO/Input.swift
+  Span+Subprocess.swift
+  AsyncBufferSequence.swift
+  API.swift
+  SubprocessFoundation/Span+SubprocessFoundation.swift
+  SubprocessFoundation/Output+Foundation.swift
+  SubprocessFoundation/Input+Foundation.swift
+  Configuration.swift)
+
+if(WIN32)
+  target_sources(Subprocess PRIVATE Platforms/Subprocess+Windows.swift)
+elseif(LINUX OR ANDROID)
+  target_sources(Subprocess PRIVATE
+    Platforms/Subprocess+Linux.swift
+    Platforms/Subprocess+Unix.swift)
+elseif(APPLE)
+  target_sources(Subprocess PRIVATE
+    Platforms/Subprocess+Darwin.swift
+    Platforms/Subprocess+Unix.swift)
+endif()

--- a/Sources/_SubprocessCShims/CMakeLists.txt
+++ b/Sources/_SubprocessCShims/CMakeLists.txt
@@ -1,3 +1,14 @@
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift.org open source project
+##
+## Copyright (c) 2025 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0 with Runtime Library Exception
+##
+## See https://swift.org/LICENSE.txt for license information
+##
+##===----------------------------------------------------------------------===##
+
 target_sources(Subprocess PRIVATE process_shims.c)
 
 target_include_directories(Subprocess PRIVATE

--- a/Sources/_SubprocessCShims/CMakeLists.txt
+++ b/Sources/_SubprocessCShims/CMakeLists.txt
@@ -1,0 +1,4 @@
+target_sources(Subprocess PRIVATE process_shims.c)
+
+target_include_directories(Subprocess PRIVATE
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>")

--- a/Sources/_SubprocessCShims/include/module.modulemap
+++ b/Sources/_SubprocessCShims/include/module.modulemap
@@ -1,0 +1,4 @@
+module _SubprocessCShims {
+  header "process_shims.h"
+  header "target_conditionals.h"
+}

--- a/Sources/_SubprocessCShims/process_shims.c
+++ b/Sources/_SubprocessCShims/process_shims.c
@@ -43,6 +43,10 @@
 extern char **environ;
 #endif
 
+#if __has_include(<mach/vm_page_size.h>)
+#include <mach/vm_page_size.h>
+#endif
+
 int _was_process_exited(int status) {
     return WIFEXITED(status);
 }

--- a/cmake/modules/InstallExternalDependencies.cmake
+++ b/cmake/modules/InstallExternalDependencies.cmake
@@ -1,3 +1,14 @@
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift.org open source project
+##
+## Copyright (c) 2025 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0 with Runtime Library Exception
+##
+## See https://swift.org/LICENSE.txt for license information
+##
+##===----------------------------------------------------------------------===##
+
 include_guard()
 
 # TODO: Use find_package to find a pre-built SwiftSystem

--- a/cmake/modules/InstallExternalDependencies.cmake
+++ b/cmake/modules/InstallExternalDependencies.cmake
@@ -1,0 +1,16 @@
+include_guard()
+
+# TODO: Use find_package to find a pre-built SwiftSystem
+
+include(FetchContent)
+
+FetchContent_Declare(SwiftSystem
+  GIT_REPOSITORY https://github.com/apple/swift-system.git
+  GIT_TAG a34201439c74b53f0fd71ef11741af7e7caf01e1 # 1.4.2
+  GIT_SHALLOW YES)
+list(APPEND dependencies SwiftSystem)
+
+
+if(dependencies)
+  FetchContent_MakeAvailable(${dependencies})
+endif()


### PR DESCRIPTION
Adding an initial CMake build so that tools that need to bootstrap with CMake, like swift-build and SwiftPM, can move to this library.